### PR TITLE
Track switching the examples in the provenance graph

### DIFF
--- a/phovea.js
+++ b/phovea.js
@@ -22,5 +22,17 @@ module.exports = function (registry) {
     factory: 'stateCompressor'
   });
 
+  registry.push('actionFunction', 'vegaSetSpec', function () {
+    return import ('./src/internal/cmds')
+  }, {
+    factory: 'setSpecImpl'
+  });
+
+  registry.push('actionCompressor', 'vegaSetSpec', function () {
+    return import ('./src/internal/cmds')
+  }, {
+    factory: 'specCompressor'
+  });
+
   // generator-phovea:end
 };

--- a/src/internal/App.ts
+++ b/src/internal/App.ts
@@ -5,7 +5,7 @@
 import * as d3 from 'd3';
 import * as $ from 'jquery';
 import {IVisStateApp} from 'phovea_clue/src/provenance_retrieval/IVisState';
-import {cat, IObjectRef} from 'phovea_core/src/provenance';
+import {cat, IObjectRef, ref} from 'phovea_core/src/provenance';
 import {EventHandler} from 'phovea_core/src/event';
 import ProvenanceGraph from 'phovea_core/src/provenance/ProvenanceGraph';
 import CLUEGraphManager from 'phovea_clue/src/CLUEGraphManager';
@@ -16,6 +16,7 @@ import {VegaView} from './VegaView';
 import {Spec} from 'vega-lib';
 import * as vega from 'vega-lib';
 import {showLoadErrorDialog} from '../dialogs';
+import {setSpec} from './cmds';
 
 export default class App extends EventHandler implements IView<App>, IVisStateApp {
   /**
@@ -23,6 +24,7 @@ export default class App extends EventHandler implements IView<App>, IVisStateAp
    * @type {IObjectRef<App>}
    */
   readonly ref: IObjectRef<App>;
+  private currentSpec: Spec = null;
 
   private readonly $node: d3.Selection<App>;
 
@@ -36,7 +38,7 @@ export default class App extends EventHandler implements IView<App>, IVisStateAp
 
     // add OrdinoApp app as (first) object to provenance graph
     // need old name for compatibility
-    this.ref = this.graph.findOrAddObject(this, 'App', cat.visual);
+    this.ref = this.graph.findOrAddObject(ref(this, 'App', cat.visual));
 
     this.$node = d3.select(parent)
       .append('div')
@@ -84,7 +86,7 @@ export default class App extends EventHandler implements IView<App>, IVisStateAp
             const dataUrl = (url.indexOf('vega.github.io') > -1) ? this.vegaDatasetUrl : '';
             return this.transformToAbsoluteUrls(spec, dataUrl);
           })
-          .then((spec: Spec) => this.openVegaView(spec))
+          .then((spec: Spec) => this.switchVegaSpec(spec, 'External Specification'))
           .catch(showLoadErrorDialog);
 
         return false;
@@ -125,13 +127,13 @@ export default class App extends EventHandler implements IView<App>, IVisStateAp
           .filter((d, i) => i === $select.property('selectedIndex'))
           .data();
         if (datasets.length > 0) {
-          this.openVegaView(datasets[0].spec);
+          this.switchVegaSpec(datasets[0].spec, datasets[0].title);
         }
       });
 
     if (datasets.length > 0) {
-      return this.openVegaView(datasets[0].spec)
-        .then(() => this);
+      this.switchVegaSpec(datasets[0].spec, datasets[0].title);
+      return Promise.resolve(this);
     }
 
     this.$node.html('No available Vega Specs loaded');
@@ -155,6 +157,47 @@ export default class App extends EventHandler implements IView<App>, IVisStateAp
     return spec;
   }
 
+  /**
+   * Switch the currently loaded Vega specification.
+   * Push the new specification to the provenance graph and open it in the vega view
+   * @param {Spec} spec
+   * @param {string} title
+   */
+  private switchVegaSpec(spec: Spec, title: string) {
+    const bak = this.currentSpec;
+    this.currentSpec = spec;
+    this.graph
+      .pushWithResult(setSpec(this.ref, spec, title), {
+        inverse: setSpec(this.ref, bak, title)
+      })
+      .then(() => this.setSpecImpl(spec))
+  }
+
+  /**
+   * Set a given specification.
+   * This function is registered and called from the provenance graph.
+   * @param {Spec} spec
+   * @returns {Spec}
+   */
+  setSpecImpl(spec: Spec) {
+    const bak = this.currentSpec;
+    this.currentSpec = spec;
+
+    if(spec) {
+      this.openVegaView(spec);
+
+    } else if(this.vegaView) {
+      this.vegaView.remove();
+    }
+
+    return bak;
+  }
+
+  /**
+   * Open a new Vega view for the given specification
+   * @param {Spec} spec
+   * @returns {Promise<VegaView>}
+   */
   private openVegaView(spec: Spec): Promise<VegaView> {
     // remove old view first
     if (this.vegaView) {

--- a/src/internal/VegaView.ts
+++ b/src/internal/VegaView.ts
@@ -129,7 +129,11 @@ export class VegaView implements IView<VegaView> {
     }
     // activate all CLUE signals by default
     this.clueSignals.forEach((d) => this.activeSignals.set(d.name, true));
-    return [...this.clueSignals, ...signals];
+
+    // find and add CLUE signals that has not been added before
+    const newClueSignals = this.clueSignals.filter((d) => !signals.some((s) => s.name === d.name));
+
+    return [...newClueSignals, ...signals];
   }
 
   private initSelector(selector: string, data: any[], isActiveMap: Map<string, boolean>) {

--- a/src/internal/cmds.ts
+++ b/src/internal/cmds.ts
@@ -1,8 +1,11 @@
 import {cat, IObjectRef, meta, action, op, ActionNode} from 'phovea_core/src/provenance';
 import {VegaView} from './VegaView';
 import {lastOnly} from 'phovea_clue/src/compress';
+import App from './App';
+import {Spec} from 'vega-lib';
 
 export const CMD_SET_STATE = 'vegaSetState';
+export const CMD_SET_SPEC = 'vegaSetSpec';
 
 export async function setStateImpl(inputs: IObjectRef<any>[], parameter: any) {
   const view = await inputs[0].v;
@@ -21,4 +24,22 @@ export function setState(view: IObjectRef<VegaView>, state: any) {
 
 export function stateCompressor(path: ActionNode[]) {
   return lastOnly(path, CMD_SET_STATE, (n) => n.requires[0].hash);
+}
+
+export async function setSpecImpl(inputs: IObjectRef<any>[], parameter: any) {
+  const view = await inputs[0].v;
+  const old = view.setSpecImpl(parameter.spec);
+  return {
+    inverse: setSpec(inputs[0], old)
+  };
+}
+
+export function setSpec(view: IObjectRef<App>, spec: Spec, title: string = 'Vega Example') {
+  return action(meta(`Open '${title}' Example`, cat.data, op.update), CMD_SET_SPEC, setSpecImpl, [view], {
+    spec
+  });
+}
+
+export function specCompressor(path: ActionNode[]) {
+  return lastOnly(path, CMD_SET_SPEC, (n) => n.requires[0].hash);
 }


### PR DESCRIPTION
Closes #5

@sgratzl I tried to track the loaded example specifications as well. I encounter some bugs that I do not know how to fix it. Could you please have a look and fix it and/or explain it?

## Bug 1: Always adding new dataset on reload

![vega_clue_always-adding-new-dataset](https://user-images.githubusercontent.com/5851088/37654558-e2618718-2c42-11e8-81f4-b07065252ad6.gif)

1. Load a new provenance graph
2. Do something
3. Reload the page creates a new branch

**Expected:** Run to the end of the first branch

## Bug 2: Longer chains are not replayed

![vega_clue-replay-error](https://user-images.githubusercontent.com/5851088/37654717-64750f68-2c43-11e8-9d28-13f1d737a8e1.gif)

![image](https://user-images.githubusercontent.com/5851088/37654712-6039de88-2c43-11e8-9a7d-f8a5b4138351.png)

```
cmds.ts:12 Uncaught (in promise) TypeError: Cannot read property 'setStateImpl' of undefined
    at ActionNode.<anonymous> (cmds.ts:12)
    at Generator.next (<anonymous>)
    at fulfilled (tslib.es6.js:62)

tslib.es6.js:63 Uncaught (in promise) TypeError: Cannot read property 'setStateImpl' of undefined
    at ActionNode.<anonymous> (cmds.ts:12)
    at Generator.next (<anonymous>)
    at fulfilled (tslib.es6.js:62)
```

