### PR TITLE
Add Gapminder Tracking

### DIFF
--- a/data/gapminder/gapminder.vg.json
+++ b/data/gapminder/gapminder.vg.json
@@ -89,11 +89,8 @@
     {
       "name": "currentYear",
       "value": 1980,
-      "on":[{
-        "events": "mousemove, touchmove",
-        "update": "currentYear"
-      }],
-      "bind": {"input": "range", "min": 1800, "max": 2015, "step": 1}
+      "bind": {"input": "range", "min": 1800, "max": 2015, "step": 1},
+      "track": true
     },
     {
       "name": "xField",

--- a/data/gapminder/gapminder.vg.json
+++ b/data/gapminder/gapminder.vg.json
@@ -70,51 +70,94 @@
       ]
     },
     {
-      "name": "trackCountries",
+      "name": "selectedCountries",
       "on": [
-        {"trigger": "active", "toggle": "{country: active.country}"}
+        {"trigger": "clear", "remove": true},
+        {"trigger": "!shift", "remove": true},
+        {"trigger": "!shift && clicked", "insert": "clicked"},
+        {"trigger": "shift && clicked", "toggle": "clicked"}
       ]
     }
   ],
 
   "signals": [
     {
-      "name": "active",
-      "value": {},
+      "name": "selectedCountries",
       "on": [
-        {"events": "@point:mousedown, @point:touchstart", "update": "datum"},
-        {"events": "window:mouseup, window:touchend", "update": "{}"}
+        {"events": {"signal": "clicked"}, "update": "null", "force": true}
+      ],
+      "track": {
+        "async": [
+          {"data": "selectedCountries", "as": "allCountries"},
+          {"signal": "clicked", "as": "lastCountry"}
+        ],
+        "title": "Selected {{lastCountry.country}} ({{allCountries.length}} Countries)"
+      }
+    },
+    {
+      "name": "clear",
+      "value": true,
+      "on": [
+        {"events": "mouseup[!event.item]", "update": "true", "force": true}
+      ],
+      "track": {
+        "async": [],
+        "title": "No Countries Selected"
+      }
+    },
+    {
+      "name": "shift",
+      "value": false,
+      "on": [
+        {"events": "@point:click", "update": "event.shiftKey", "force": true}
+      ]
+    },
+    {
+      "name": "clicked",
+      "value": null,
+      "on": [
+        {"events": "@point:click", "update": "datum", "force": true}
       ]
     },
     {
       "name": "currentYear",
       "value": 1980,
       "bind": {"input": "range", "min": 1800, "max": 2015, "step": 1},
-      "track": true
+      "track": {
+        "title": "Selected Year {{value}}"
+      }
     },
     {
       "name": "xField",
       "value": "fertility",
       "bind": {"input": "select", "options": ["gdp", "child_mortality", "fertility", "life_expect", "population"]},
-      "track": true
+      "track": {
+        "title": "X = {{value}}"
+      }
     },
     {
       "name": "yField",
       "value": "life_expect",
       "bind": {"input": "select", "options": ["gdp", "child_mortality", "fertility", "life_expect", "population"]},
-      "track": true
+      "track": {
+        "title": "Y = {{value}}"
+      }
     },
     {
       "name": "sizeField",
       "value": "population",
       "bind": {"input": "select", "options": ["gdp", "child_mortality", "fertility", "life_expect", "population"]},
-      "track": true
+      "track": {
+        "title": "Size = {{value}}"
+      }
     },
     {
       "name": "colorField",
       "value": "continent",
       "bind": {"input": "select", "options": ["continent", "main_religion"]},
-      "track": true
+      "track": {
+        "title": "Color = {{value}}"
+      }
     }
   ],
 
@@ -205,7 +248,7 @@
           "size": {"scale": "size", "field": "size"},
           "fillOpacity": [
             {
-              "test": "indata('trackCountries', 'country', datum.country)",
+              "test": "indata('selectedCountries', 'country', datum.country)",
               "value": 1
             },
             {"value": 0.5}
@@ -237,7 +280,7 @@
           "y": {"scale": "y", "field": "y", "offset": -7},
           "fillOpacity": [
             {
-              "test": "indata('trackCountries', 'country', datum.country)",
+              "test": "indata('selectedCountries', 'country', datum.country)",
               "value": 0.8
             },
             {"value": 0}

--- a/data/gapminder/gapminder.vg.json
+++ b/data/gapminder/gapminder.vg.json
@@ -91,7 +91,9 @@
           {"data": "selectedCountries", "as": "allCountries"},
           {"signal": "clicked", "as": "lastCountry"}
         ],
-        "title": "Selected {{lastCountry.country}} ({{allCountries.length}} Countries)"
+        "title": "Selected {{lastCountry.country}} ({{allCountries.length}} Countries)",
+        "category": "selection",
+        "operation": "update"
       }
     },
     {
@@ -102,7 +104,9 @@
       ],
       "track": {
         "async": [],
-        "title": "No Countries Selected"
+        "title": "No Countries Selected",
+        "category": "selection",
+        "operation": "update"
       }
     },
     {
@@ -132,7 +136,9 @@
       "value": "fertility",
       "bind": {"input": "select", "options": ["gdp", "child_mortality", "fertility", "life_expect", "population"]},
       "track": {
-        "title": "X = {{value}}"
+        "title": "X = {{value}}",
+        "category": "data",
+        "operation": "update"
       }
     },
     {
@@ -140,7 +146,9 @@
       "value": "life_expect",
       "bind": {"input": "select", "options": ["gdp", "child_mortality", "fertility", "life_expect", "population"]},
       "track": {
-        "title": "Y = {{value}}"
+        "title": "Y = {{value}}",
+        "category": "data",
+        "operation": "update"
       }
     },
     {
@@ -148,7 +156,9 @@
       "value": "population",
       "bind": {"input": "select", "options": ["gdp", "child_mortality", "fertility", "life_expect", "population"]},
       "track": {
-        "title": "Size = {{value}}"
+        "title": "Size = {{value}}",
+        "category": "data",
+        "operation": "update"
       }
     },
     {
@@ -156,7 +166,9 @@
       "value": "continent",
       "bind": {"input": "select", "options": ["continent", "main_religion"]},
       "track": {
-        "title": "Color = {{value}}"
+        "title": "Color = {{value}}",
+        "category": "data",
+        "operation": "update"
       }
     }
   ],

--- a/data/gapminder/gapminder.vg.json
+++ b/data/gapminder/gapminder.vg.json
@@ -98,22 +98,26 @@
     {
       "name": "xField",
       "value": "fertility",
-      "bind": {"input": "select", "options": ["gdp", "child_mortality", "fertility", "life_expect", "population"]}
+      "bind": {"input": "select", "options": ["gdp", "child_mortality", "fertility", "life_expect", "population"]},
+      "track": true
     },
     {
       "name": "yField",
       "value": "life_expect",
-      "bind": {"input": "select", "options": ["gdp", "child_mortality", "fertility", "life_expect", "population"]}
+      "bind": {"input": "select", "options": ["gdp", "child_mortality", "fertility", "life_expect", "population"]},
+      "track": true
     },
     {
       "name": "sizeField",
       "value": "population",
-      "bind": {"input": "select", "options": ["gdp", "child_mortality", "fertility", "life_expect", "population"]}
+      "bind": {"input": "select", "options": ["gdp", "child_mortality", "fertility", "life_expect", "population"]},
+      "track": true
     },
     {
       "name": "colorField",
       "value": "continent",
-      "bind": {"input": "select", "options": ["continent", "main_religion"]}
+      "bind": {"input": "select", "options": ["continent", "main_religion"]},
+      "track": true
     }
   ],
 

--- a/src/internal/VegaView.ts
+++ b/src/internal/VegaView.ts
@@ -6,7 +6,7 @@ import * as handlebars from 'handlebars/dist/handlebars';
 import * as d3 from 'd3';
 import * as vega from 'vega-lib';
 import {Spec, View, BindRange} from 'vega-lib';
-import {setState} from './cmds';
+import {ISetStateMetadata, setState} from './cmds';
 import {ClueSignal, IAsyncData, IAsyncSignal} from './spec';
 
 
@@ -65,15 +65,23 @@ export class VegaView implements IView<VegaView> {
           });
 
         const template = handlebars.compile(signalSpec.track.title);
-        const title = template(context);
-        this.pushNewGraphNode(title, vegaView.getState());
+        const metadata: ISetStateMetadata = {
+          name: template(context),
+          category: signalSpec.track.category || 'data',
+          operation: signalSpec.track.operation || 'update'
+        };
+        this.pushNewGraphNode(metadata, vegaView.getState());
       });
 
     } else {
       const rawTitle = (signalSpec.track.title) ? signalSpec.track.title : `{{name}} = {{value}}`;
       const template = handlebars.compile(rawTitle);
-      const title = template(context);
-      this.pushNewGraphNode(title, vegaView.getState());
+      const metadata: ISetStateMetadata = {
+        name: template(context),
+        category: signalSpec.track.category || 'data',
+        operation: signalSpec.track.operation || 'update'
+      };
+      this.pushNewGraphNode(metadata, vegaView.getState());
     }
   }
 
@@ -120,12 +128,12 @@ export class VegaView implements IView<VegaView> {
     return bak;
   }
 
-  private pushNewGraphNode(title: string, state: any) {
+  private pushNewGraphNode(metadata: ISetStateMetadata, state: any) {
     // capture vega state and add to history
     const bak = this.currentState;
     this.currentState = state;
-    this.graph.pushWithResult(setState(this.ref, title, state), {
-      inverse: setState(this.ref, title, bak)
+    this.graph.pushWithResult(setState(this.ref, metadata, state), {
+      inverse: setState(this.ref, metadata, bak)
     });
   }
 

--- a/src/internal/VegaView.ts
+++ b/src/internal/VegaView.ts
@@ -31,7 +31,13 @@ export class VegaView implements IView<VegaView> {
   readonly ref: IObjectRef<VegaView>;
   private currentState: any = null;
 
+  private blockSignalHandler: boolean = false;
+
   private signalHandler = (name, value) => {
+    if(this.blockSignalHandler) {
+      return;
+    }
+
     // cast to <any>, because `getState()` is missing in 'vega-typings'
     const vegaView = (<any>this.$node.datum());
     const signalSpec: ClueSignal = <ClueSignal>this.spec.signals.find((d) => d.name === name)!;
@@ -93,7 +99,12 @@ export class VegaView implements IView<VegaView> {
     const vegaView = <any>this.$node.datum();
     const bak = this.currentState;
     this.currentState = state;
+
+    // prevent adding the provenance graph node twice
+    this.blockSignalHandler = true;
     vegaView.setState(state);
+    this.blockSignalHandler = false;
+
     return bak;
   }
 

--- a/src/internal/VegaView.ts
+++ b/src/internal/VegaView.ts
@@ -48,6 +48,16 @@ export class VegaView implements IView<VegaView> {
     const signalSpec: ClueSignal = <ClueSignal>this.spec.signals.find((d) => d.name === name)!;
     const context = {name, value};
 
+    function createMetadata(): ISetStateMetadata {
+      const rawTitle = (signalSpec.track.title) ? signalSpec.track.title : `{{name}} = {{value}}`;
+      const template = handlebars.compile(rawTitle);
+      return {
+        name: template(context),
+        category: signalSpec.track.category || 'data',
+        operation: signalSpec.track.operation || 'update'
+      };
+    }
+
     if(signalSpec.track.async) {
       vegaView.runAsync().then((view) => {
         const async = signalSpec.track.async;
@@ -64,24 +74,11 @@ export class VegaView implements IView<VegaView> {
             context[key] = view.data(d.data);
           });
 
-        const template = handlebars.compile(signalSpec.track.title);
-        const metadata: ISetStateMetadata = {
-          name: template(context),
-          category: signalSpec.track.category || 'data',
-          operation: signalSpec.track.operation || 'update'
-        };
-        this.pushNewGraphNode(metadata, vegaView.getState());
+        this.pushNewGraphNode(createMetadata(), vegaView.getState());
       });
 
     } else {
-      const rawTitle = (signalSpec.track.title) ? signalSpec.track.title : `{{name}} = {{value}}`;
-      const template = handlebars.compile(rawTitle);
-      const metadata: ISetStateMetadata = {
-        name: template(context),
-        category: signalSpec.track.category || 'data',
-        operation: signalSpec.track.operation || 'update'
-      };
-      this.pushNewGraphNode(metadata, vegaView.getState());
+      this.pushNewGraphNode(createMetadata(), vegaView.getState());
     }
   }
 

--- a/src/internal/VegaView.ts
+++ b/src/internal/VegaView.ts
@@ -3,8 +3,15 @@ import {IView} from '../AppWrapper';
 import {cat, IObjectRef, ref} from 'phovea_core/src/provenance';
 import * as d3 from 'd3';
 import * as vega from 'vega-lib';
-import {Spec, Signal, View} from 'vega-lib';
+import {Spec, View, NewSignal, BindCheckbox, BindRadioSelect, BindRange} from 'vega-lib';
 import {setState} from './cmds';
+
+/**
+ * Extend the Vega Signal specification about tracking
+ */
+interface ClueSignal extends NewSignal {
+  track: boolean;
+}
 
 interface IVegaViewOptions {
   /**
@@ -19,51 +26,37 @@ export class VegaView implements IView<VegaView> {
     vegaRenderer: 'svg',
   };
 
-  /**
-   * RegExp to activate the signal when the string contains `mouseup`, `touchend`, or `click`.
-   * @type {RegExp}
-   */
-  private readonly activateSignal: RegExp = /(mouseup|touchend|click)/g;
-
-  /**
-   * List of signals that are used by this CLUE connector
-   * @type {Signal[]}
-   */
-  private readonly clueSignals: Signal[] = [
-    {
-      'name': 'CLUE_captureState',
-      'value': null,
-      'on': [
-        {'events': 'mousedown, touchstart', 'update': 'null', 'force': true}
-      ]
-    }
-  ];
-
   private readonly $node: d3.Selection<View>;
-
-  private readonly activeSignals: Map<string, boolean> = new Map<string, boolean>();
 
   readonly ref: IObjectRef<VegaView>;
   private currentState: any = null;
 
   private signalHandler = (name, value) => {
-    // ignore signals that are not listed or disabled
-    if (!this.activeSignals.has(name) || !this.activeSignals.get(name)) {
-      return;
-    }
-
     // cast to <any>, because `getState()` is missing in 'vega-typings'
     const vegaView = (<any>this.$node.datum());
-    console.log(name, value, vegaView.getState());
+    const signalSpec: ClueSignal = <ClueSignal>this.spec.signals.find((d) => d.name === name)!;
+    console.log(name, value, vegaView.getState(), signalSpec);
+
+    let actionName = ``;
+
+    if(signalSpec.bind) {
+      switch ((<BindCheckbox | BindRadioSelect | BindRange>signalSpec.bind).input) {
+        case 'select':
+        case 'radio':
+          actionName = `${name} = ${value}`;
+          break;
+        case 'range':
+          console.log('changed range binding');
+          break;
+      }
+    }
 
     // capture vega state and add to history
-    if (name === this.clueSignals[0].name) {
-      const bak = this.currentState;
-      this.currentState = vegaView.getState();
-      this.graph.pushWithResult(setState(this.ref, vegaView.getState()), {
-        inverse: setState(this.ref, bak)
-      });
-    }
+    const bak = this.currentState;
+    this.currentState = vegaView.getState();
+    this.graph.pushWithResult(setState(this.ref, `${name} = ${value}`, vegaView.getState()), {
+      inverse: setState(this.ref, `${name} = ${value}`, bak)
+    });
   }
 
   constructor(parent: HTMLElement, private readonly graph: ProvenanceGraph, private spec: Spec) {
@@ -73,24 +66,11 @@ export class VegaView implements IView<VegaView> {
       .append('div')
       .classed('vega-view', true)
       .html(`
-        <!--<div class="side-panel">
-          <button class="btn btn-default btn-undo"><i class="fa fa-undo"></i> Undo</button>
-          <button class="btn btn-default btn-redo"><i class="fa fa-repeat"></i> Redo</button>
-          <hr>
-          <form class="signal-selector"><p><strong>List of signals</strong></p></form>
-        </div>-->
         <div class="vega-wrapper"></div>
       `);
   }
 
   init(): Promise<VegaView> {
-    this.spec.signals = this.initClueSignals(this.spec.signals);
-
-    // set default values for signals -- default: true
-    //this.spec.signals.forEach((d) => this.activeSignals.set(d.name, this.shouldSignalBeActive(d)));
-
-    //this.initSelector('.signal-selector', this.spec.signals, this.activeSignals);
-
     const vegaView: View = new View(vega.parse(this.spec))
       //.logLevel(vega.Warn) // set view logging level
       .renderer(this.options.vegaRenderer)  // set renderer (canvas or svg)
@@ -106,49 +86,7 @@ export class VegaView implements IView<VegaView> {
     vegaView.run(); // run after defining the promise
     this.$node.datum(vegaView);
 
-    /*this.$node.select('.btn-undo')
-      .on('click', () => {
-        this.graph.undo();
-      });
-
-    this.$node.select('.btn-redo')
-      .on('click', () => {
-        // NOT possible
-        const next = this.graph.act.nextState;
-        if (next) {
-          this.graph.jumpTo(next);
-        }
-      });*/
-
     return vegaViewReady.then(() => this);
-  }
-
-  private initClueSignals(signals: Signal[]): Signal[] {
-    if (!signals) {
-      signals = [];
-    }
-    // activate all CLUE signals by default
-    this.clueSignals.forEach((d) => this.activeSignals.set(d.name, true));
-    return [...this.clueSignals, ...signals];
-  }
-
-  private initSelector(selector: string, data: any[], isActiveMap: Map<string, boolean>) {
-    const $signals = this.$node.select(selector)
-      .selectAll('.checkbox').data(data);
-
-    $signals.enter()
-      .append('div')
-      .classed('checkbox', true)
-      .html(`<label><input type="checkbox"><span></span></label>`);
-
-    $signals.select('span').text((d) => d.name);
-    $signals.select('input')
-      .attr('checked', (d) => (isActiveMap.get(d.name)) ? 'checked' : null)
-      .on('change', (d) => {
-        isActiveMap.set(d.name, !isActiveMap.get(d.name));
-      });
-
-    $signals.exit().remove();
   }
 
   setStateImpl(state: any) {
@@ -168,30 +106,21 @@ export class VegaView implements IView<VegaView> {
 
   private addSignalListener(vegaView: View) {
     if (this.spec.signals) {
-      this.spec.signals.forEach((signal) => {
-        vegaView.addSignalListener(signal.name, this.signalHandler);
-      });
+      this.spec.signals
+        .filter((signal: ClueSignal) => signal.track)
+        .forEach((signal) => {
+          vegaView.addSignalListener(signal.name, this.signalHandler);
+        });
     }
   }
 
   private removeSignalListener(vegaView: View) {
     if (this.spec.signals) {
-      this.spec.signals.forEach((signal) => {
-        vegaView.removeSignalListener(signal.name, this.signalHandler);
-      });
+      this.spec.signals
+        .filter((signal: ClueSignal) => signal.track)
+        .forEach((signal) => {
+          vegaView.removeSignalListener(signal.name, this.signalHandler);
+        });
     }
-  }
-
-  /**
-   * Check all events of the signal.
-   * If the event contains a `mouseup`, `touchend`, or `click` then activate the signal.
-   * Otherwise deactivate the signal.
-   * @param {Signal} signal
-   */
-  private shouldSignalBeActive(signal: Signal): boolean {
-    if (!signal.on) {
-      return false;
-    }
-    return signal.on.some((d) => this.activateSignal.test(d.events.toString()));
   }
 }

--- a/src/internal/cmds.ts
+++ b/src/internal/cmds.ts
@@ -8,12 +8,13 @@ export async function setStateImpl(inputs: IObjectRef<any>[], parameter: any) {
   const view = await inputs[0].v;
   const old = view.setStateImpl(parameter.state);
   return {
-    inverse: setState(inputs[0], old)
+    inverse: setState(inputs[0], parameter.name, old)
   };
 }
 
-export function setState(view: IObjectRef<VegaView>, state: any) {
-  return action(meta('Change State', cat.visual, op.update), CMD_SET_STATE, setStateImpl, [view], {
+export function setState(view: IObjectRef<VegaView>, name: string, state: any) {
+  return action(meta(name, cat.visual, op.update), CMD_SET_STATE, setStateImpl, [view], {
+    name,
     state
   });
 }

--- a/src/internal/cmds.ts
+++ b/src/internal/cmds.ts
@@ -2,6 +2,26 @@ import {cat, IObjectRef, meta, action, op, ActionNode} from 'phovea_core/src/pro
 import {VegaView} from './VegaView';
 import {lastOnly} from 'phovea_clue/src/compress';
 
+
+export interface ISetStateMetadata {
+  /**
+   * Title of the graph node
+   */
+  name: string,
+
+  /**
+   * Category of this signal
+   * @see 'phovea_core/src/provenance/ObjectNode.ts'
+   */
+  category: 'data' | 'selection' | 'visual' | 'layout' | 'logic' | 'custom' | 'annotation';
+
+  /**
+   * Operations of this signal
+   * @see 'phovea_core/src/provenance/ObjectNode.ts'
+   */
+  operation: 'create' | 'update' | 'remove';
+}
+
 export const CMD_SET_STATE = 'vegaSetState';
 
 export async function setStateImpl(inputs: IObjectRef<any>[], parameter: any) {
@@ -12,8 +32,8 @@ export async function setStateImpl(inputs: IObjectRef<any>[], parameter: any) {
   };
 }
 
-export function setState(view: IObjectRef<VegaView>, name: string, state: any) {
-  return action(meta(name, cat.visual, op.update), CMD_SET_STATE, setStateImpl, [view], {
+export function setState(view: IObjectRef<VegaView>, metadata: ISetStateMetadata, state: any) {
+  return action(meta(metadata.name, metadata.category, metadata.operation), CMD_SET_STATE, setStateImpl, [view], {
     name,
     state
   });

--- a/src/internal/spec.ts
+++ b/src/internal/spec.ts
@@ -30,6 +30,20 @@ export interface ITrackedSignal {
    */
   async?: TrackedSignalAsync[];
 
+  /**
+   * Category of this signal
+   *
+   * Default value: `data`
+   */
+  category?: 'data' | 'selection' | 'visual' | 'layout' | 'logic' | 'custom' | 'annotation';
+
+  /**
+   * Operations of this signal
+   *
+   * Default value: `update`
+   */
+  operation?: 'create' | 'update' | 'remove';
+
 }
 
 interface IBaseAsync {

--- a/src/internal/spec.ts
+++ b/src/internal/spec.ts
@@ -1,0 +1,58 @@
+import {NewSignal} from 'vega-lib';
+
+/**
+ * Extend the Vega Signal specification about tracking
+ */
+export interface ClueSignal extends NewSignal {
+  track: ITrackedSignal;
+}
+
+/**
+ * Extend the Vega Signal specification about tracking
+ */
+export interface ITrackedSignal {
+
+  /**
+   * Title of the graph node
+   * It can contain Handlebar.js syntax to replace variables.
+   * @see http://handlebarsjs.com/
+   *
+   * Available default variables:
+   * * `{{name}}`: signal name
+   * * `{{value}}`: signal value
+   *
+   * Further variables can be added by using the `async` option.
+   */
+  title: string;
+
+  /**
+   * If set wait for completing dataflow evaluation
+   */
+  async?: TrackedSignalAsync[];
+
+}
+
+interface IBaseAsync {
+  /**
+   * If set use this alias name for replacement in the title
+   */
+  as?: string;
+}
+
+export interface IAsyncData extends IBaseAsync {
+  /**
+   * A valid dataset name
+   */
+  data: string;
+}
+
+export interface IAsyncSignal extends IBaseAsync {
+  /**
+   * A valid signal name
+   */
+  signal: string;
+}
+
+type TrackedSignalAsync = IAsyncData | IAsyncSignal;
+
+


### PR DESCRIPTION
Closes #11 

![gapminder-tracking](https://user-images.githubusercontent.com/5851088/37840038-55e559e6-2ebc-11e8-822d-75f8b3ed1144.gif)

## Usage

Tracking is implemented by adding a `track` property to a signal definition.

```json
{
  "name": "colorField",
  "value": "continent",
  "bind": {"input": "select", "options": ["continent", "main_religion"]},
  "track": {
	"title": "Color = {{value}}"
  }
}
```

The `title` property is used for the node name in the provenance graph and can contain [Handlebar.js](https://handlebarsjs.com) syntax. 

In case further data is required to generate the title we have to wait until Vega's dataflow evaluation is complete. Further values from other data or signals can then be acquired by using the `async` property.

```json
{
  "name": "selectedCountries",
  "on": [
	{"events": {"signal": "clicked"}, "update": "null", "force": true}
  ],
  "track": {
	"async": [
	  {"data": "selectedCountries", "as": "allCountries"},
	  {"signal": "clicked", "as": "lastCountry"}
	],
	"title": "Selected {{lastCountry.country}} ({{allCountries.length}} Countries)"
  }
}
```

It is also possible to define a category and an operation for the node in the provenance graph:

```json
...
  "track": {
	"title": "Selected {{lastCountry.country}} ({{allCountries.length}} Countries)",
    "category": "selection",
    "operation": "update"
  }
...
```

Possible options are:
* category: `data` (default), `selection`, `visual`, `layout`, `logic`, `custom`, `annotation` 
* operation: `create`, `update` (default), `remove`

## Open Issues

* #13
