### PR TITLE
Connect Gapminder to retrieval index

### DIFF
--- a/data/gapminder/gapminder.vg.json
+++ b/data/gapminder/gapminder.vg.json
@@ -80,7 +80,8 @@
       "search": {
         "type": "set",
         "title": "{{datum.country}}",
-        "group": {"signal": "groupLabelCountries"}
+        "group": {"signal": "groupLabelCountries"},
+        "fill": {"source": "countries"}
       }
     }
   ],
@@ -138,7 +139,10 @@
       "search": {
         "type": "number",
         "title": "{{value}}",
-        "group": {"signal": "groupLabelYear"}
+        "group": {"signal": "groupLabelYear"},
+        "fill": {
+          "range": {"min": 1800, "max": 2015, "step": 1}
+        }
       }
     },
     {

--- a/data/gapminder/gapminder.vg.json
+++ b/data/gapminder/gapminder.vg.json
@@ -76,7 +76,12 @@
         {"trigger": "!shift", "remove": true},
         {"trigger": "!shift && clicked", "insert": "clicked"},
         {"trigger": "shift && clicked", "toggle": "clicked"}
-      ]
+      ],
+      "search": {
+        "type": "set",
+        "title": "{{datum.country}}",
+        "group": {"signal": "groupLabelCountries"}
+      }
     }
   ],
 
@@ -129,6 +134,11 @@
       "bind": {"input": "range", "min": 1800, "max": 2015, "step": 1},
       "track": {
         "title": "Selected Year {{value}}"
+      },
+      "search": {
+        "type": "number",
+        "title": "{{value}}",
+        "group": {"signal": "groupLabelYear"}
       }
     },
     {
@@ -139,6 +149,11 @@
         "title": "X = {{value}}",
         "category": "data",
         "operation": "update"
+      },
+      "search": {
+        "type": "category",
+        "title": "{{value}}",
+        "group": {"signal": "groupLabelAttributes"}
       }
     },
     {
@@ -149,6 +164,11 @@
         "title": "Y = {{value}}",
         "category": "data",
         "operation": "update"
+      },
+      "search": {
+        "type": "category",
+        "title": "{{value}}",
+        "group": {"signal": "groupLabelAttributes"}
       }
     },
     {
@@ -159,6 +179,11 @@
         "title": "Size = {{value}}",
         "category": "data",
         "operation": "update"
+      },
+      "search": {
+        "type": "category",
+        "title": "{{value}}",
+        "group": {"signal": "groupLabelAttributes"}
       }
     },
     {
@@ -169,10 +194,15 @@
         "title": "Color = {{value}}",
         "category": "data",
         "operation": "update"
+      },
+      "search": {
+        "type": "category",
+        "title": "{{value}}",
+        "group": {"signal": "groupLabelAttributes"}
       }
     },
     {
-      "name": "update_statistics",
+      "name": "updateStatistics",
       "description": "Collect all variables that could change and trigger an update for the statistic values",
       "on": [
         {"events": {"signal": "clicked"}, "update": "null", "force": true},
@@ -189,71 +219,132 @@
       "description": "Statistics needs to be implemented. Random value as proof of concept.",
       "value": 0,
       "on": [
-        {"events": {"signal": "update_statistics"}, "update": "random()"}
-      ]
+        {"events": {"signal": "updateStatistics"}, "update": "random()"}
+      ],
+      "search": {
+        "type": "number",
+        "title": "{{name}} = {{round value 2}}",
+        "group": {"signal": "groupLabelStatistics"}
+      }
     },
     {
       "name": "skewed",
       "description": "Statistics needs to be implemented. Random value as proof of concept.",
       "value": 0,
       "on": [
-        {"events": {"signal": "update_statistics"}, "update": "random()"}
-      ]
+        {"events": {"signal": "updateStatistics"}, "update": "random()"}
+      ],
+      "search": {
+        "type": "number",
+        "title": "{{name}} = {{round value 2}}",
+        "group": {"signal": "groupLabelStatistics"}
+      }
     },
     {
       "name": "clumpy",
       "description": "Statistics needs to be implemented. Random value as proof of concept.",
       "value": 0,
       "on": [
-        {"events": {"signal": "update_statistics"}, "update": "random()"}
-      ]
+        {"events": {"signal": "updateStatistics"}, "update": "random()"}
+      ],
+      "search": {
+        "type": "number",
+        "title": "{{name}} = {{round value 2}}",
+        "group": {"signal": "groupLabelStatistics"}
+      }
     },
     {
       "name": "sparse",
       "description": "Statistics needs to be implemented. Random value as proof of concept.",
       "value": 0,
       "on": [
-        {"events": {"signal": "update_statistics"}, "update": "random()"}
-      ]
+        {"events": {"signal": "updateStatistics"}, "update": "random()"}
+      ],
+      "search": {
+        "type": "number",
+        "title": "{{name}} = {{round value 2}}",
+        "group": {"signal": "groupLabelStatistics"}
+      }
     },
     {
       "name": "striated",
       "description": "Statistics needs to be implemented. Random value as proof of concept.",
       "value": 0,
       "on": [
-        {"events": {"signal": "update_statistics"}, "update": "random()"}
-      ]
+        {"events": {"signal": "updateStatistics"}, "update": "random()"}
+      ],
+      "search": {
+        "type": "number",
+        "title": "{{name}} = {{round value 2}}",
+        "group": {"signal": "groupLabelStatistics"}
+      }
     },
     {
       "name": "convex",
       "description": "Statistics needs to be implemented. Random value as proof of concept.",
       "value": 0,
       "on": [
-        {"events": {"signal": "update_statistics"}, "update": "random()"}
-      ]
+        {"events": {"signal": "updateStatistics"}, "update": "random()"}
+      ],
+      "search": {
+        "type": "number",
+        "title": "{{name}} = {{round value 2}}",
+        "group": {"signal": "groupLabelStatistics"}
+      }
     },
     {
       "name": "skinny",
       "description": "Statistics needs to be implemented. Random value as proof of concept.",
       "value": 0,
       "on": [
-        {"events": {"signal": "update_statistics"}, "update": "random()"}
-      ]
+        {"events": {"signal": "updateStatistics"}, "update": "random()"}
+      ],
+      "search": {
+        "type": "number",
+        "title": "{{name}} = {{round value 2}}",
+        "group": {"signal": "groupLabelStatistics"}
+      }
     },
     {
       "name": "stringy",
       "description": "Statistics needs to be implemented. Random value as proof of concept.",
       "on": [
-        {"events": {"signal": "update_statistics"}, "update": "random()"}
-      ]
+        {"events": {"signal": "updateStatistics"}, "update": "random()"}
+      ],
+      "search": {
+        "type": "number",
+        "title": "{{name}} = {{round value 2}}",
+        "group": {"signal": "groupLabelStatistics"}
+      }
     },
     {
       "name": "monotonic",
       "description": "Statistics needs to be implemented. Random value as proof of concept.",
       "value": 0,
       "on": [
-        {"events": {"signal": "update_statistics"}, "update": "random()"}
-      ]
+        {"events": {"signal": "updateStatistics"}, "update": "random()"}
+      ],
+      "search": {
+        "type": "number",
+        "title": "{{name}} = {{round value 2}}",
+        "group": {"signal": "groupLabelStatistics"}
+      }
+    },
+    {
+      "name": "groupLabelStatistics",
+      "value": "Scatterplot Statistics"
+    },
+    {
+      "name": "groupLabelAttributes",
+      "value": "Attributes"
+    },
+    {
+      "name": "groupLabelCountries",
+      "value": "Selected Countries"
+    },
+    {
+      "name": "groupLabelYear",
+      "value": "Selected Year"
     }
   ],
 

--- a/data/gapminder/gapminder.vg.json
+++ b/data/gapminder/gapminder.vg.json
@@ -170,6 +170,90 @@
         "category": "data",
         "operation": "update"
       }
+    },
+    {
+      "name": "update_statistics",
+      "description": "Collect all variables that could change and trigger an update for the statistic values",
+      "on": [
+        {"events": {"signal": "clicked"}, "update": "null", "force": true},
+        {"events": {"signal": "clear"}, "update": "null", "force": true},
+        {"events": {"signal": "currentYear"}, "update": "null", "force": true},
+        {"events": {"signal": "xField"}, "update": "null", "force": true},
+        {"events": {"signal": "yField"}, "update": "null", "force": true},
+        {"events": {"signal": "sizeField"}, "update": "null", "force": true},
+        {"events": {"signal": "colorField"}, "update": "null", "force": true}
+      ]
+    },
+    {
+      "name": "outlying",
+      "description": "Statistics needs to be implemented. Random value as proof of concept.",
+      "value": 0,
+      "on": [
+        {"events": {"signal": "update_statistics"}, "update": "random()"}
+      ]
+    },
+    {
+      "name": "skewed",
+      "description": "Statistics needs to be implemented. Random value as proof of concept.",
+      "value": 0,
+      "on": [
+        {"events": {"signal": "update_statistics"}, "update": "random()"}
+      ]
+    },
+    {
+      "name": "clumpy",
+      "description": "Statistics needs to be implemented. Random value as proof of concept.",
+      "value": 0,
+      "on": [
+        {"events": {"signal": "update_statistics"}, "update": "random()"}
+      ]
+    },
+    {
+      "name": "sparse",
+      "description": "Statistics needs to be implemented. Random value as proof of concept.",
+      "value": 0,
+      "on": [
+        {"events": {"signal": "update_statistics"}, "update": "random()"}
+      ]
+    },
+    {
+      "name": "striated",
+      "description": "Statistics needs to be implemented. Random value as proof of concept.",
+      "value": 0,
+      "on": [
+        {"events": {"signal": "update_statistics"}, "update": "random()"}
+      ]
+    },
+    {
+      "name": "convex",
+      "description": "Statistics needs to be implemented. Random value as proof of concept.",
+      "value": 0,
+      "on": [
+        {"events": {"signal": "update_statistics"}, "update": "random()"}
+      ]
+    },
+    {
+      "name": "skinny",
+      "description": "Statistics needs to be implemented. Random value as proof of concept.",
+      "value": 0,
+      "on": [
+        {"events": {"signal": "update_statistics"}, "update": "random()"}
+      ]
+    },
+    {
+      "name": "stringy",
+      "description": "Statistics needs to be implemented. Random value as proof of concept.",
+      "on": [
+        {"events": {"signal": "update_statistics"}, "update": "random()"}
+      ]
+    },
+    {
+      "name": "monotonic",
+      "description": "Statistics needs to be implemented. Random value as proof of concept.",
+      "value": 0,
+      "on": [
+        {"events": {"signal": "update_statistics"}, "update": "random()"}
+      ]
     }
   ],
 

--- a/src/internal/App.ts
+++ b/src/internal/App.ts
@@ -196,14 +196,11 @@ export default class App extends EventHandler implements IView<App>, IVisStateAp
   }
 
   getVisStateProps(): Promise<IProperty[]> {
-    return this.initCompletePromise
-      .then(() => {
-        return [];
-      });
+    return this.initCompletePromise.then(() => this.vegaView.getVisStateProps());
   }
 
   getCurrVisState(): Promise<IPropertyValue[]> {
-    return Promise.resolve([]);
+    return this.vegaView.getCurrVisState();
   }
 
   remove() {

--- a/src/internal/App.ts
+++ b/src/internal/App.ts
@@ -31,6 +31,14 @@ export default class App extends EventHandler implements IView<App>, IVisStateAp
   private readonly vegaExampleUrl = 'https://vega.github.io/vega/examples/interactive-legend.vg.json';
   private readonly vegaDatasetUrl = 'https://vega.github.io/vega-datasets/';
 
+  /**
+   * Promise to wait for Vega view initialization, before calling `getVisStateProps()`
+   */
+  private initCompleteResolve;
+  private initCompletePromise: Promise<VegaView> = new Promise<VegaView>((resolve, reject) => {
+    this.initCompleteResolve = resolve;
+  });
+
   constructor(public readonly graph: ProvenanceGraph, public readonly graphManager: CLUEGraphManager, parent: HTMLElement) {
     super();
 
@@ -51,12 +59,16 @@ export default class App extends EventHandler implements IView<App>, IVisStateAp
   init(): Promise<App> {
     return loadDatasets()
       .then((vegaSpecs: IVegaSpecDataset[]) => {
-        this.initImpl(vegaSpecs);
-        return this;
-      });
+        if(vegaSpecs.length === 1) {
+          return this.initSingleSpec(vegaSpecs);
+        }
+        return this.initMultiSpecs(vegaSpecs);
+      })
+      .then((vegaView: VegaView) => this.initCompleteResolve(vegaView))
+      .then(() => this);
   }
 
-  private initImpl(vegaSpecs: IVegaSpecDataset[]) {
+  private initSingleSpec(vegaSpecs: IVegaSpecDataset[]): Promise<VegaView> {
     const datasets: IVegaSpecDataset[] = vegaSpecs.map((dataset: IVegaSpecDataset) => {
       if (dataset.spec.data) {
         dataset.spec = this.transformToAbsoluteUrls(dataset.spec, this.vegaDatasetUrl);
@@ -64,12 +76,17 @@ export default class App extends EventHandler implements IView<App>, IVisStateAp
       return dataset;
     });
 
-    // handle case if only gapminder dataset is available
-    if(vegaSpecs.length === 1) {
-      this.$node.html(`<div class="view-wrapper"></div>`);
-      return this.openVegaView(datasets[0].spec)
-        .then(() => this);
-    }
+    this.$node.html(`<div class="view-wrapper"></div>`);
+    return this.openVegaView(datasets[0].spec);
+  }
+
+  private initMultiSpecs(vegaSpecs: IVegaSpecDataset[]): Promise<VegaView> {
+    const datasets: IVegaSpecDataset[] = vegaSpecs.map((dataset: IVegaSpecDataset) => {
+      if (dataset.spec.data) {
+        dataset.spec = this.transformToAbsoluteUrls(dataset.spec, this.vegaDatasetUrl);
+      }
+      return dataset;
+    });
 
     this.$node.html(`
       <form class="dataset-selector form-inline" action="#">
@@ -145,8 +162,7 @@ export default class App extends EventHandler implements IView<App>, IVisStateAp
       });
 
     if (datasets.length > 0) {
-      return this.openVegaView(datasets[0].spec)
-        .then(() => this);
+      return this.openVegaView(datasets[0].spec);
     }
   }
 
@@ -180,7 +196,10 @@ export default class App extends EventHandler implements IView<App>, IVisStateAp
   }
 
   getVisStateProps(): Promise<IProperty[]> {
-    return Promise.resolve([]);
+    return this.initCompletePromise
+      .then(() => {
+        return [];
+      });
   }
 
   getCurrVisState(): Promise<IPropertyValue[]> {

--- a/src/internal/VegaView.ts
+++ b/src/internal/VegaView.ts
@@ -147,6 +147,16 @@ export class VegaView implements IView<VegaView>, IVisStateApp {
   }
 
   /**
+   * Remove event listener and the view itself
+   */
+  remove() {
+    const vegaView = this.$node.datum();
+    this.removeSignalListener(vegaView, this.spec);
+    vegaView.finalize();
+    this.$node.remove();
+  }
+
+  /**
    * Apply a given state to the current Vega view.
    *
    * @param state New state that will be applied to the Vega view
@@ -182,16 +192,6 @@ export class VegaView implements IView<VegaView>, IVisStateApp {
   }
 
   /**
-   * Remove event listener and the view itself
-   */
-  remove() {
-    const vegaView = this.$node.datum();
-    this.removeSignalListener(vegaView, this.spec);
-    vegaView.finalize();
-    this.$node.remove();
-  }
-
-  /**
    * Get all properties (i.e., groups) with the corresponding values
    * that should be available for retrieval.
    *
@@ -203,7 +203,7 @@ export class VegaView implements IView<VegaView>, IVisStateApp {
    */
   getVisStateProps(): Promise<IProperty[]> {
     if(!this.currentState) {
-      console.warn('No current Vega state available; returning an empty property list.')
+      console.warn('No current Vega state available; returning an empty property list.');
       return Promise.resolve([]);
     }
 
@@ -288,7 +288,7 @@ export class VegaView implements IView<VegaView>, IVisStateApp {
    */
   getCurrVisState(): Promise<IPropertyValue[]> {
     if(!this.currentState) {
-      console.warn('No current Vega state available; returning an empty property list.')
+      console.warn('No current Vega state available; returning an empty property list.');
       return Promise.resolve([]);
     }
 

--- a/src/internal/VegaView.ts
+++ b/src/internal/VegaView.ts
@@ -297,7 +297,7 @@ export class VegaView implements IView<VegaView>, IVisStateApp {
      * @param {ClueSignal | ClueData} input
      * @param current
      */
-    function prepareInput(input: any, current: any) {
+    const prepareInput = (input: any, current: any) => {
       return input
         .filter((d: ClueSignal | ClueData) => d.search)
         .map((d) => Object.assign({}, d)) // shallow copy object

--- a/src/internal/VegaView.ts
+++ b/src/internal/VegaView.ts
@@ -7,7 +7,12 @@ import * as d3 from 'd3';
 import * as vega from 'vega-lib';
 import {Spec, View, BindRange} from 'vega-lib';
 import {ISetStateMetadata, setState} from './cmds';
-import {ClueSignal, IAsyncData, IAsyncSignal} from './spec';
+import {ClueData, ClueSignal, IAsyncData, IAsyncSignal} from './spec';
+import {IVisStateApp} from 'phovea_clue/src/provenance_retrieval/IVisState';
+import {
+  createPropertyValue, IProperty,
+  IPropertyValue, Property, PropertyType
+} from 'phovea_core/src/provenance/retrieval/VisStateProperty';
 
 
 interface IVegaViewOptions {
@@ -23,7 +28,7 @@ interface IRangeDOMListener {
   listener: Map<string, () => void>;
 }
 
-export class VegaView implements IView<VegaView> {
+export class VegaView implements IView<VegaView>, IVisStateApp {
 
   private readonly options: IVegaViewOptions = {
     vegaRenderer: 'svg',
@@ -38,6 +43,17 @@ export class VegaView implements IView<VegaView> {
 
   private blockSignalHandler: boolean = false;
 
+  /**
+   * Run the signal handler for the given signal name.
+   *
+   * The function retrieves synchronous or asynchronous variables
+   * to replace the values in the configured title and further
+   * metadata, such as operation and category. The metadata and the
+   * Vega state are push into the provenance graph as new graph node.
+   *
+   * @param name
+   * @param value
+   */
   private signalHandler = (name, value) => {
     if(this.blockSignalHandler) {
       return;
@@ -96,6 +112,11 @@ export class VegaView implements IView<VegaView> {
       `);
   }
 
+  /**
+   * Initialize the Vega view and attach the signal listener.
+   *
+   * @returns {Promise<VegaView>}
+   */
   init(): Promise<VegaView> {
     const vegaView: View = new View(vega.parse(this.spec))
       //.logLevel(vega.Warn) // set view logging level
@@ -106,16 +127,32 @@ export class VegaView implements IView<VegaView> {
     const vegaViewReady = (<any>vegaView).runAsync() // type cast to any because `runAsync` is missing in 'vega-typings'
       .then(() => {
         this.currentState = (<any>vegaView).getState();
-        this.addSignalListener(vegaView);
+        this.addSignalListener(vegaView, this.spec);
       });
 
     vegaView.run(); // run after defining the promise
     this.$node.datum(vegaView);
 
+    this.registerHandlebarsHelper();
+
     return vegaViewReady.then(() => this);
   }
 
-  setStateImpl(state: any) {
+  /**
+   * Register handlebars helper that can be used in the title properties
+   * from the Vega specification.
+   */
+  private registerHandlebarsHelper() {
+    handlebars.registerHelper('round', (x, n) => d3.round(x, n));
+  }
+
+  /**
+   * Apply a given state to the current Vega view.
+   *
+   * @param state New state that will be applied to the Vega view
+   * @returns {any} Backup of the previous state
+   */
+  setStateImpl(state: any): any {
     const vegaView = <any>this.$node.datum();
     const bak = this.currentState;
     this.currentState = state;
@@ -128,25 +165,263 @@ export class VegaView implements IView<VegaView> {
     return bak;
   }
 
+  /**
+   * Push a new state with metadata to the provenance graph.
+   *
+   * @param {ISetStateMetadata} metadata
+   * @param state
+   */
   private pushNewGraphNode(metadata: ISetStateMetadata, state: any) {
     // capture vega state and add to history
     const bak = this.currentState;
     this.currentState = state;
+    console.log(metadata, state);
     this.graph.pushWithResult(setState(this.ref, metadata, state), {
       inverse: setState(this.ref, metadata, bak)
     });
   }
 
+  /**
+   * Remove event listener and the view itself
+   */
   remove() {
     const vegaView = this.$node.datum();
-    this.removeSignalListener(vegaView);
+    this.removeSignalListener(vegaView, this.spec);
     vegaView.finalize();
     this.$node.remove();
   }
 
-  private addSignalListener(vegaView: View) {
-    if (this.spec.signals) {
-      this.spec.signals
+  /**
+   * Get all properties (i.e., groups) with the corresponding values
+   * that should be available for retrieval.
+   *
+   * The available properties are generated based on:
+   * 1. Existing property values stored in the provenance graph
+   * 2. Predefined properties that
+   *
+   * @returns {Promise<IProperty[]>}
+   */
+  getVisStateProps(): Promise<IProperty[]> {
+    if(!this.currentState) {
+      console.warn('No current Vega state available; returning an empty property list.')
+      return Promise.resolve([]);
+    }
+
+    const propertyValues = this.getPropertyValuesFromGraph(this.graph);
+    const groups: {group: string, type: string}[] = this.getGroupsFromVegaSpec(this.spec, this.currentState);
+
+    // create properties from groups
+    const properties = groups.map((g) => {
+      const propVals =  propertyValues
+        .filter((d) => d && d.group === g.group)
+        .filter((d, i, arr) => arr.findIndex((e) => e.id === d.id) === arr.lastIndexOf(d)) // make values unique
+        .map((prop) => prop.clone())
+        .map((prop) => {
+          // special handling for numerical properties
+          if(prop.type === PropertyType.NUMERICAL) {
+            prop.text = `${prop.id} = <i>&lt;number&gt;</i>`;
+            prop.needsInput = true;
+          }
+          return prop;
+        });
+
+      switch (g.type) {
+        case 'number':
+          return new Property(PropertyType.NUMERICAL, g.group, propVals);
+        case 'category':
+          return new Property(PropertyType.CATEGORICAL, g.group, propVals);
+        case 'set':
+          return new Property(PropertyType.SET, g.group, propVals);
+      }
+      return undefined;
+    })
+    .filter((s) => s); // filter undefined values
+
+    return Promise.resolve(properties);
+  }
+
+  /**
+   * Get existing property values that are stored in the provenance graph as list.
+   * Duplicates are possible.
+   *
+   * @param {ProvenanceGraph} graph
+   * @returns {IPropertyValue[]}
+   */
+  private getPropertyValuesFromGraph(graph: ProvenanceGraph): IPropertyValue[] {
+    return graph.states
+      .map((s) => s.visState)
+      .filter((vs) => vs.isPersisted())
+      .map((vs) => vs.propValues)
+      .reduce((prev, curr) => prev.concat(curr), []); // flatten the array
+  }
+
+  /**
+   * Extract the group and type from the `data` and `signals` section
+   * of the Vega specification.
+   *
+   * Signal references in the group definition will be resolved
+   * with the values from the current state.
+   *
+   * @param {Spec} spec
+   * @param currentState
+   * @returns {{group: string; type: string}[]}
+   */
+  private getGroupsFromVegaSpec(spec: Spec, currentState: any): {group: string, type: string}[]  {
+    return [...spec.signals, ...spec.data]
+      .map((s: ClueSignal) => {
+        if(s.search && s.search.group) {
+          return {
+            group: this.resolveSignalReference(s.search.group, this.currentState),
+            type: s.search.type
+          };
+        }
+        return undefined;
+      })
+      .filter((s) => s); // filter undefined values
+  }
+
+  /**
+   * Get property values that describe the current visualization state
+   * and should be available later for retrieval.
+   *
+   * @returns {Promise<IPropertyValue[]>}
+   */
+  getCurrVisState(): Promise<IPropertyValue[]> {
+    if(!this.currentState) {
+      console.warn('No current Vega state available; returning an empty property list.')
+      return Promise.resolve([]);
+    }
+
+    /**
+     * Resolve signal references in the input data and set the values from the current state
+     * @param {ClueSignal | ClueData} input
+     * @param current
+     */
+    function prepareInput(input: any, current: any) {
+      return input
+        .filter((d: ClueSignal | ClueData) => d.search)
+        .map((d) => Object.assign({}, d)) // shallow copy object
+        .map((d: ClueSignal | ClueData) => {
+          if(d.search && d.search.group) {
+            d.search.group = this.resolveSignalReference(d.search.group, this.currentState);
+          }
+          d.value = current[d.name];
+          return d;
+        });
+    }
+
+    let propertyValues: IPropertyValue[];
+    const signals = prepareInput(this.spec.signals, this.currentState.signals);
+    propertyValues = signals.map((s) => this.signalToPropertyValue(s));
+
+    prepareInput(this.spec.data, this.currentState.data)
+      .forEach((d) => {
+        // add each element individually
+        propertyValues = [...propertyValues, ...this.dataToPropertyValue(d)];
+      });
+
+    return Promise.resolve(propertyValues);
+  }
+
+  /**
+   * Create property values from a given signal property.
+   *
+   * At the moment this function only creates numerical and category.
+   *
+   * @param {ClueSignal} signal
+   * @returns {IPropertyValue}
+   */
+  private signalToPropertyValue(signal: ClueSignal): IPropertyValue {
+    const context = {name: signal.name, value: signal.value};
+    let rawTitle, template;
+
+    switch(signal.search.type) {
+      case 'number':
+        rawTitle = (signal.search.title) ? signal.search.title : `{{name}} = {{round value 2}}`;
+        template = handlebars.compile(rawTitle);
+
+        return createPropertyValue(PropertyType.NUMERICAL, {
+          id: signal.name,
+          text: template(context),
+          group: signal.search.group,
+          payload: {
+            numVal: signal.value
+          }
+        });
+
+      case 'category':
+        rawTitle = (signal.search.title) ? signal.search.title : `{{value}}`;
+        template = handlebars.compile(rawTitle);
+
+        return createPropertyValue(PropertyType.CATEGORICAL, {
+          id: signal.name,
+          text: template(context),
+          group: signal.search.group
+        });
+    }
+
+    console.warn(`Undefined search type ${signal.search.type} for signal '${signal.name}'.`);
+    return undefined;
+  }
+
+  /**
+   * Create property values from a given data property.
+   *
+   * At the moment this function only works with arrays for `data.value`,
+   * which will create one SET property value for each item in the array.
+   *
+   * @param {ClueData} data
+   * @returns {IPropertyValue[]}
+   */
+  private dataToPropertyValue(data: ClueData): IPropertyValue[] {
+    let propVals = [];
+
+    if(Array.isArray(data.value) && data.search.type === 'set') {
+      const rawTitle = (data.search.title) ? data.search.title : `{{name}}_{{index}}`;
+      const template = handlebars.compile(rawTitle);
+
+      propVals = data.value.map((d, i) => {
+        const context = {name: data.name, datum: d, index: i};
+        const title = template(context);
+        return createPropertyValue(PropertyType.SET, {
+          id: title, // Special case! Use title also id to make items distinguishable, because name is equal for all items
+          text: title,
+          group: data.search.group
+        });
+      });
+
+    } else {
+      console.warn(`Undefined search type ${data.search.type} for signal '${data.name}'.`);
+    }
+
+    return propVals;
+  }
+
+  /**
+   * Resolve a signal reference in a spec property with the value from the given current state.
+   * If a string instead of a signal reference is given, it will just return the string.
+   *
+   * @param {{signal: string} | string} specProperty
+   * @param currentState
+   * @returns {{signal: string} | string}
+   */
+  private resolveSignalReference(specProperty: {signal: string} | string, currentState: any): string {
+    if(!specProperty) {
+      return;
+    }
+
+    const signalRef: string = (<any>specProperty).signal;
+    return (signalRef) ? currentState.signals[signalRef] : specProperty;
+  }
+
+  /**
+   * Add signal listener to Vega view based on the given specification
+   * @param {View} vegaView
+   * @param {Spec} spec
+   */
+  private addSignalListener(vegaView: View, spec: Spec) {
+    if (spec.signals) {
+      spec.signals
         .filter((signal: ClueSignal) => signal.track)
         .forEach((signal: ClueSignal) => {
           // check for range input
@@ -159,9 +434,14 @@ export class VegaView implements IView<VegaView> {
     }
   }
 
-  private removeSignalListener(vegaView: View) {
-    if (this.spec.signals) {
-      this.spec.signals
+  /**
+   * Remove signal listener to Vega view based on the given specification
+   * @param {View} vegaView
+   * @param {Spec} spec
+   */
+  private removeSignalListener(vegaView: View, spec: Spec) {
+    if (spec.signals) {
+      spec.signals
         .filter((signal: ClueSignal) => signal.track)
         .forEach((signal) => {
           vegaView.removeSignalListener(signal.name, this.signalHandler);

--- a/src/internal/spec.ts
+++ b/src/internal/spec.ts
@@ -1,16 +1,17 @@
-import {NewSignal} from 'vega-lib';
+import {NewSignal, Data} from 'vega-lib';
 
 /**
  * Extend the Vega Signal specification about tracking
  */
 export interface ClueSignal extends NewSignal {
-  track: ITrackedSignal;
+  track?: ITrackProv;
+  search?: ISearchProv;
 }
 
 /**
  * Extend the Vega Signal specification about tracking
  */
-export interface ITrackedSignal {
+export interface ITrackProv {
 
   /**
    * Title of the graph node
@@ -28,7 +29,7 @@ export interface ITrackedSignal {
   /**
    * If set wait for completing dataflow evaluation
    */
-  async?: TrackedSignalAsync[];
+  async?: TrackProvAsync[];
 
   /**
    * Category of this signal
@@ -67,6 +68,78 @@ export interface IAsyncSignal extends IBaseAsync {
   signal: string;
 }
 
-type TrackedSignalAsync = IAsyncData | IAsyncSignal;
+type TrackProvAsync = IAsyncData | IAsyncSignal;
 
 
+interface ISearchProv {
+
+  /**
+   * Title of the graph node
+   * It can contain Handlebar.js syntax to replace variables.
+   * @see http://handlebarsjs.com/
+   *
+   * Available default variables in signal definitions:
+   * - `{{name}}`: signal or dataset name
+   * - `{{value}}`: signal value
+   *
+   * Available default variables in data definitions:
+   * - `{{name}}`: signal or dataset name
+   * - `{{datum}}`: single datum from the dataset array
+   * - `{{index}}`: index of the current datum in the array
+   *
+   * Default values:
+   * - numerical: `{{name}} = {{round value 2}}`
+   * - categorical: `{{value}}`
+   * - set: `{{name}}_{{index}}`
+   *
+   */
+  title: string;
+
+  /**
+   * Property type
+   * - `number`
+   *   Only available for signal definitions.
+   *   On retrieval the user will be prompted to input a number.
+   *   The closer the input value to the stored value, the higher the similarity.
+   *
+   *
+   * - `category`
+   *   Only available for signal definitions.
+   *   On retrieval the user has to select the correct categorical value to get an exact match.
+   *
+   * - `set`
+   *   Only available for data definitions.
+   *   List of elements which are searchable.
+   *   On retrieval a set comparison using the Jaccard index is performed.
+   */
+  type: 'number' | 'category' | 'set';
+
+  /**
+   * Group name or signal reference
+   */
+  group: ISearchProvGroup | string;
+
+}
+
+export interface ISearchProvGroup {
+  /**
+   * A valid signal name
+   */
+  signal: string;
+}
+
+
+/**
+ * Extend the Vega Data specification about search
+ */
+export type ClueData = Data & {
+  /**
+   * Define
+   */
+  search?: ISearchProv;
+
+  /**
+   * Helper property to make it equal to the signal typings
+   */
+  value: any;
+}

--- a/src/internal/spec.ts
+++ b/src/internal/spec.ts
@@ -119,6 +119,11 @@ interface ISearchProv {
    */
   group: ISearchProvGroup | string;
 
+  /**
+   * Fill the search suggestions with more (disabled) options as preview
+   */
+  fill: ISearchProvFill;
+
 }
 
 export interface ISearchProvGroup {
@@ -128,6 +133,36 @@ export interface ISearchProvGroup {
   signal: string;
 }
 
+export interface ISearchProvFill {
+  /**
+   * Reference to another valid dataset to create search suggestions from an array.
+   * Note: Works only for type `set`
+   */
+  source?: string;
+
+  /**
+   * Create create search suggestions from a range.
+   * Note: Works only for type `numbe`
+   */
+  range?: ISearchProvFillRange;
+}
+
+export interface ISearchProvFillRange {
+  /**
+   * Minimum value
+   */
+  min: number;
+
+  /**
+   * Maximum value
+   */
+  max: number;
+
+  /**
+   * Step size
+   */
+  step: number;
+}
 
 /**
  * Extend the Vega Data specification about search


### PR DESCRIPTION
Closes #6

![gapminder-retrieval](https://user-images.githubusercontent.com/5851088/37892288-aa27896c-30d7-11e8-9218-d52c8e7dc05b.gif)


## Usage

Tracking is implemented by adding a `search` property to a `signal` or `data` definition.

```json
{
  "name": "colorField",
  "value": "continent",
  "bind": {"input": "select", "options": ["continent", "main_religion"]},
  "search": {
	"type": "category",
	"title": "{{value}}",
	"group": {"signal": "groupLabelAttributes"}
  }
},
{
  "name": "groupLabelAttributes",
  "value": "Attributes"
},
```

The `title` property is used for the node name in the provenance graph and can contain [Handlebar.js](https://handlebarsjs.com) syntax. 

The `type` property must be either
* `category` for categorical data defined in signals
* `number` for numerical data defined in signals
* `set` for array data defined in datasets

The `group` property can group multiple signals or datasets (of the same type) using a common identifier. The `group` can be either a string or a signal reference that will be used as group title (see Figure > A)

![gapminder-group](https://user-images.githubusercontent.com/5851088/37892902-ae3845c6-30d9-11e8-8058-49f3d4e77607.png)

### Fill Properties <a name="fill" href="#fill">#</a> 

By default the search suggestions contain only values that are already stored in graph nodes of the provenance graph. You can use the `fill` property to define a source or range and fill a group with further options.

**Fill Range**
The fill range property is only available for search type `number` and must contain a `min`, `max` and `step`.

```json
{
  "name": "currentYear",
  "value": 1980,
  "bind": {"input": "range", "min": 1800, "max": 2015, "step": 1},
  "search": {
	"type": "number",
	"title": "{{value}}",
	"group": {"signal": "groupLabelYear"},
	"fill": {
	  "range": {"min": 1800, "max": 2015, "step": 1}
	}
  }
},
```

Results in:

![image](https://user-images.githubusercontent.com/5851088/37893068-356994b4-30da-11e8-9b86-03f496269006.png)

**Fill Sources**
The fill sources property is only availalbe for search type `set` and must contain a reference to an array dataset.

```json
{
  "name": "countries",
  "source": "gapminder",
  "transform": [
	{"type": "aggregate", "groupby": ["country"]}
  ]
},
{
  "name": "selectedCountries",
  "on": [
	{"trigger": "clear", "remove": true},
	{"trigger": "!shift", "remove": true},
	{"trigger": "!shift && clicked", "insert": "clicked"},
	{"trigger": "shift && clicked", "toggle": "clicked"}
  ],
  "search": {
	"type": "set",
	"title": "{{datum.country}}",
	"group": {"signal": "groupLabelCountries"},
	"fill": {"source": "countries"}
  }
}
```

Results in:

![image](https://user-images.githubusercontent.com/5851088/37893193-95530752-30da-11e8-8a68-86e95442cbc4.png)

Note: Countries that have never been selected (i.e., that are not stored in the provenance graph) are disabled.


